### PR TITLE
Keep search query visible on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -145,7 +145,7 @@ function App() {
   return (
     <>
     <AuthContext.Provider value={{ isUserAuthenticated, setIsUserAuthenticated }}>
-      <Navbar onSearch={setSearch} />
+      <Navbar onSearch={setSearch} initialSearch={search} />
 
       {isHomePage && <BannerImage />}
       

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -5,7 +5,6 @@ import Search from './Search';
 import logo from '../assets/logo.png';
 import { Link as RouterLink } from 'react-router-dom';
 import UserProfileButton from "./UserProfileButton";
-import { RiAccountCircleLine } from "react-icons/ri";
 
 const Links = [
     { label: 'Home', path: '/' },
@@ -13,7 +12,7 @@ const Links = [
     { label: 'About', path: '/about' },
 ];
 
-export default function Navbar({ onSearch }) {
+export default function Navbar({ onSearch, initialSearch }) {
     const [open, setOpen] = useState(false);
 
     return (
@@ -126,6 +125,7 @@ export default function Navbar({ onSearch }) {
                                     <Search
                                         onSearch={onSearch}
                                         onFinish={() => setOpen(false)}
+                                        initialSearch={initialSearch}
                                     />
                                 </Box>
                             </Drawer.Content>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -10,10 +10,11 @@ import { useNavigate } from 'react-router-dom';
 type SearchProps = {
     onSearch: (query: string) => void;
     onFinish?: () => void;
+    initialSearch: string;
 }
 
-export default function Search({ onSearch, onFinish }: SearchProps) {
-    const [search, setSearch] = useState<string>("");
+export default function Search({ onSearch, onFinish, initialSearch }: SearchProps) {
+    const [search, setSearch] = useState<string>(initialSearch);
     const navigate = useNavigate();
     const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -25,7 +26,7 @@ export default function Search({ onSearch, onFinish }: SearchProps) {
         }
     };
 
-    function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
         if (e.key === 'Enter') {
             if (window.location.pathname !== "/") {
                 navigate("/")


### PR DESCRIPTION
The search query was not displayed on a mobile device. 
The component now stores local state but initialises it from the parent component.
The search component still manages its own state and stores user input.

const [search, setSearch] = useState<string>(initialSearch)
