### PR TITLE
updated useEffect dependencies for proper scrolling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -102,7 +102,7 @@ function App() {
     if (!isLoading) {
       setCombinedArtworks((aicDataArtworks?.pages ?? []).concat(hamDataArtworks?.pages ?? []).flatMap(page => page.artworks))
     }
-  }, [isLoading, aicDataArtworks, hamDataArtworks])
+  }, [ isLoading, search ])
 
   const { ref, inView, entry } = useInView({
   });


### PR DESCRIPTION
After the last changes, scrolling was not working correctly - artworks were stuck and not in order.

Added `search` to the `useEffect` dependency array, which fixes the problem and ensures artworks load and scroll in the correct order.